### PR TITLE
Evict failed futures from cache; replace deprecated get_event_loop

### DIFF
--- a/src/cachetools_async/decorators.py
+++ b/src/cachetools_async/decorators.py
@@ -1,4 +1,4 @@
-from asyncio import Future, Task, get_event_loop, shield
+from asyncio import Future, Task, get_running_loop, shield
 from functools import update_wrapper
 from inspect import iscoroutinefunction
 from typing import (
@@ -72,11 +72,17 @@ def cached(
                 if future.exception() is None:
                     return future.result()
 
+                # Evict failed futures so they don't occupy cache slots
+                try:
+                    del cache[k]
+                except KeyError:
+                    pass
+
             coro = fn(*args, **kwargs)
 
-            loop = get_event_loop()
+            loop = get_running_loop()
 
-            # Crete a task that tracks the coroutine execution
+            # Create a task that tracks the coroutine execution
             task = loop.create_task(coro)
 
             # Create a future and then tie the future and task together
@@ -139,11 +145,17 @@ def cachedmethod(
                 if future.exception() is None:
                     return future.result()
 
+                # Evict failed futures so they don't occupy cache slots
+                try:
+                    del c[k]
+                except KeyError:
+                    pass
+
             coro = method(self, *args, **kwargs)
 
-            loop = get_event_loop()
+            loop = get_running_loop()
 
-            # Crete a task that tracks the coroutine execution
+            # Create a task that tracks the coroutine execution
             task = loop.create_task(coro)
 
             # Create a future and then tie the future and task together

--- a/tests/test_cached.py
+++ b/tests/test_cached.py
@@ -126,6 +126,28 @@ class TestCachedDict:
 
         assert await decorated_fn() == "example"
 
+    async def test_failed_futures_are_evicted_from_cache(self):
+        cache = {}
+        mock = AsyncMock()
+
+        mock.side_effect = [
+            TypeError(),
+            "example",
+        ]
+
+        decorated_fn = cachetools_async.cached(cache)(mock)
+
+        with pytest.raises(TypeError):
+            await decorated_fn("foo")
+
+        # The failed future should have been evicted on the next call
+        await decorated_fn("foo")
+        assert len(cache) == 1
+
+        # The successful result should now be cached
+        future = cache[list(cache.keys())[0]]
+        assert future.result() == "example"
+
     async def test_cache_clear_evicts_everything(self):
         mock = AsyncMock()
 

--- a/tests/test_cachedmethod.py
+++ b/tests/test_cachedmethod.py
@@ -144,6 +144,30 @@ class TestCachedmethodDict:
 
         assert await decorated_fn(mock) == "example"
 
+    async def test_failed_futures_are_evicted_from_cache(self):
+        cache = {}
+        mock_resolver = MagicMock()
+        mock_resolver.return_value = cache
+
+        mock = AsyncMock()
+        mock.func.side_effect = [
+            TypeError(),
+            "example",
+        ]
+
+        decorated_fn = cachetools_async.cachedmethod(mock_resolver)(mock.func)
+
+        with pytest.raises(TypeError):
+            await decorated_fn(mock, "foo")
+
+        # The failed future should have been evicted on the next call
+        await decorated_fn(mock, "foo")
+        assert len(cache) == 1
+
+        # The successful result should now be cached
+        future = cache[list(cache.keys())[0]]
+        assert future.result() == "example"
+
     async def test_cache_clear_evicts_everything(self, mock_resolver):
         mock = AsyncMock()
         mock.return_value = "bar"


### PR DESCRIPTION
## Summary

- **Evict failed futures from cache**: When a cached future has completed with an exception, the decorator correctly re-executes the function on the next call. However, the stale failed future was never removed from the cache, permanently occupying a slot. With bounded caches (e.g. `LRUCache`), this can cause valid entries to be evicted. This change explicitly `del`s failed futures before re-executing.
- **Replace `get_event_loop()` with `get_running_loop()`**: `asyncio.get_event_loop()` has been deprecated since Python 3.10. Since these decorators are only called from within async contexts, `get_running_loop()` is the correct replacement.
- **Fix typo**: "Crete" → "Create" in comments.

Both `cached` and `cachedmethod` are fixed.

## Test plan

- [x] New tests `test_failed_futures_are_evicted_from_cache` for both `cached` and `cachedmethod` verify that after a failed call, the cache slot is freed and a subsequent successful call populates it correctly
- [x] All 27 existing + new tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)